### PR TITLE
fix: Use enumerated indices for ForEach identifiers

### DIFF
--- a/ACarouselDemo/ACarouselDemo.xcodeproj/project.pbxproj
+++ b/ACarouselDemo/ACarouselDemo.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -326,7 +326,7 @@
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEVELOPMENT_ASSET_PATHS = "\"ACarouselDemo iOS/Preview Content\"";
-				DEVELOPMENT_TEAM = FJ92PFEJWW;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
@@ -402,7 +402,7 @@
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_ASSET_PATHS = "\"ACarouselDemo iOS/Preview Content\"";
-				DEVELOPMENT_TEAM = FJ92PFEJWW;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_PREVIEWS = YES;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;

--- a/Sources/ACarousel/ACarousel.swift
+++ b/Sources/ACarousel/ACarousel.swift
@@ -41,10 +41,11 @@ public struct ACarousel<Data, ID, Content> : View where Data : RandomAccessColle
     
     private func generateContent(proxy: GeometryProxy) -> some View {
         HStack(spacing: viewModel.spacing) {
-            ForEach(viewModel.data, id: viewModel.dataId) {
-                content($0)
+            ForEach(Array(viewModel.data.enumerated()), id: \.offset) { index, item in
+                content(item)
                     .frame(width: viewModel.itemWidth)
-                    .scaleEffect(x: 1, y: viewModel.itemScaling($0), anchor: .center)
+                    .scaleEffect(x: 1, y: viewModel.itemScaling(item), anchor: .center)
+                    .id(index)
             }
         }
         .frame(width: proxy.size.width, height: proxy.size.height, alignment: .leading)

--- a/Sources/ACarousel/ACarouselViewModel.swift
+++ b/Sources/ACarousel/ACarouselViewModel.swift
@@ -101,7 +101,11 @@ class ACarouselViewModel<Data, ID>: ObservableObject where Data : RandomAccessCo
     /// Ignores listen when App will resign active, and listen again when it become active
     private var isTimerActive = true
     func setTimerActive(_ active: Bool) {
-        isTimerActive = active
+        if case ACarouselAutoScroll.inactive = autoScroll {
+            isTimerActive = false
+        } else {
+            isTimerActive = active
+        }
     }
     
 }


### PR DESCRIPTION
Removes implicit Hashable requirement on Data.Element by using array indices
for ForEach identification instead of the data elements themselves. This
maintains the original generic constraints while providing stable view
identities.